### PR TITLE
#106 Add nineoldandroids to dependencies in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ repositories {
 
 dependencies {
     compile 'com.github.navasmdc:MaterialDesign:1.+@aar'
+    compile 'com.nineoldandroids:library:2.4.+'
 }
 ```
 


### PR DESCRIPTION
Adding the nineoldandroids dependency to my app's build.gradle fixed #106 for me. Looks like it fixed #106 for several others.
